### PR TITLE
fix minor typo in 7.4

### DIFF
--- a/src/bgnet0_part_0700_ipv4.md
+++ b/src/bgnet0_part_0700_ipv4.md
@@ -227,7 +227,7 @@ network, subnets were split into 3 main classes:
 
 * **Class A** - Subnet mask `255.0.0.0` (or `/8`), supports 16,777,214 hosts
 * **Class B** - Subnet mask `255.255.0.0` (or `/16`), supports 65,534 hosts
-* **Class C** - Subnet mask `255.255.255.0` (or `/24`) supports 253 hosts
+* **Class C** - Subnet mask `255.255.255.0` (or `/24`) supports 254 hosts
 
 The problem was that this caused a really uneven distribution of
 subnets, which some large companies getting 16 million hosts (that they


### PR DESCRIPTION
I think this line is a typo:

`Class C - Subnet mask 255.255.255.0 (or /24) supports 253 hosts`

As there are 256 - 2 reserved addresses i.e. 254 hosts. Fixed that in my PR. 

Thank you for such a terrific networking resource