### PR TITLE
Bugfix wordserver: Prefix with length in bytes, not length in Unicode characters

### DIFF
--- a/source/exercises/word/wordserver.py
+++ b/source/exercises/word/wordserver.py
@@ -44,7 +44,7 @@ def build_word_packet(word_count):
     for _ in range(word_count):
         word = random.choice(WORDS)
         word_bytes = word.encode()
-        word_len = len(word)
+        word_len = len(word_bytes)
         word_len_bytes = word_len.to_bytes(WORD_LEN_SIZE, "big")
 
         word_packet += word_len_bytes + word_bytes


### PR DESCRIPTION
As described in section 13.2 of the Word Server project, each packet should contain a UTF-8 encoded word "prefixed by the length of the word in bytes".
However, the current implementation actually [uses the length in characters](https://github.com/beejjorgensen/bgnet0/blob/578a97a140f625a3aed0904a0ced72413eb4cf4d/source/exercises/word/wordserver.py#L47), which differs if a word contains multi-byte characters.

Fixing this by using the length in bytes of the encoded word (`len(word_bytes)`) instead of the length in characters of the un-encoded word (`len(word)`).
