### PR TITLE
Fix wikipedia MUD link

### DIFF
--- a/src/bgnet0_part_3900_chat.md
+++ b/src/bgnet0_part_3900_chat.md
@@ -386,7 +386,7 @@ doesn't get accidentally messed up!
   first join, but additions could be to add chat rooms, join or leave
   chat rooms, and list available chat rooms.
 
-* Turn the whole thing into a [MUD](https://en.wikipedia.org/wiki/MUD).
+* Turn the whole thing into a [MUD](https://en.wikipedia.org/wiki/Multi-user_dungeon).
   That should keep you busy!
 
 ## Some Recommendations


### PR DESCRIPTION
The old one is currently redirected to a disambiguation page.

This change assumes that the use of "MUD" here is in reference to a "multi-user dungeon". I could probably verify this by looking at the history of the old link on Wikipedia, but I don't know how to do that off the top of my head...